### PR TITLE
Include R4.0 in CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
       local-dir: docs
       on:
         branch: master
+  - r: 3.6.2
   - r: 3.5.1
   - r: 3.4.1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ init:
 install:
   ps: Bootstrap
 
-cache:
-  - C:\RLibrary
+#cache:
+#  - C:\RLibrary
 
 # Adapt as necessary starting from here
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,6 +60,9 @@ environment:
   matrix:
   - R_VERSION: release
     R_ARCH: x64
+    
+  - R_VERSION: 3.6.2
+    R_ARCH: x64
 
   - R_VERSION: 3.5.1
     R_ARCH: x64


### PR DESCRIPTION
In fact, it's not included in travis yet, but added 3.6.2 as additional version and release will 
switch to 4.0 whenever it is provided by Travis. 

On the other hand, Appveyor seems to have some cache issues with v4.0.